### PR TITLE
fix: useEffect when SSR

### DIFF
--- a/src/useTweaks.ts
+++ b/src/useTweaks.ts
@@ -1,8 +1,9 @@
-import { useState, useLayoutEffect, useRef } from 'react'
+import { useState, useRef } from 'react'
 import Tweakpane from 'tweakpane'
 
 import { getData, buildPane } from './data'
 import { Schema, Settings, UseTweaksValues } from './types'
+import { useIsomorphicLayoutEffect } from './utils'
 
 let ROOTPANE: Tweakpane | undefined
 
@@ -18,7 +19,7 @@ export function useTweaks<T extends Schema>(
 
   const [data, set] = useState(() => getData(_schema.current, _rootKey))
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     ROOTPANE = ROOTPANE || new Tweakpane({ ..._settings, container: _settings.current?.container?.current! })
     const isRoot = _name === undefined
     const _pane = _name ? ROOTPANE.addFolder({ title: _name }) : ROOTPANE

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,7 @@
+import { useEffect, useLayoutEffect } from 'react'
+
 export function uuid(): string {
   return `${Math.floor((new Date().getTime() * Math.random()) / 1000)}`
 }
+
+export const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect


### PR DESCRIPTION
When SSR, `useLayoutEffect` prints a warning. This PR fixes this by swapping the hook with a `useEffect` if we are on the server. This is a common way to solve this problem:

- https://github.com/streamich/react-use/blob/6737092ad9260ca1fe481bf4c10ffa650ae35476/src/useIsomorphicLayoutEffect.ts
- https://github.com/mui-org/material-ui/blob/e53a9543cf28b67be6216e5f0ffd99be553cb258/packages/material-ui-utils/src/useEnhancedEffect.js

![Screenshot 2020-11-06 at 11 00 15](https://user-images.githubusercontent.com/5436545/98353179-42b27a00-201f-11eb-88cb-76a489bb0695.png)
